### PR TITLE
fixed typo

### DIFF
--- a/antonyhanna/itzg-minecraft-server-cf.xml
+++ b/antonyhanna/itzg-minecraft-server-cf.xml
@@ -22,7 +22,6 @@
 	<Labels/>
 	<ExtraParams>-i -t</ExtraParams>
 	<Config Name="EULA" Target="EULA" Default="true" Mode="" Description="End User License Agreement" Type="Variable" Display="always" Required="true" Mask="false">true</Config>
-	<Config Name="Version" Target="VERSION" Default="" Mode="" Description="Server Version" Type="Variable" Display="always" Required="true" Mask="false"></Config>
 	<Config Name="Server Port" Target="25565" Default="25565" Mode="tcp" Description="Host Port" Type="Port" Display="always" Required="true" Mask="false">25565</Config>
 	<Config Name="Data" Target="/data" Default="!" Mode="/mnt/cache/appdata/minecraft-server" Description="Data Mount" Type="Path" Display="always" Required="true" Mask="false">/mnt/cache/appdata/minecraft-server</Config>
 	<Config Name="Type" Target="TYPE" Default="CURSEFORGE" Mode="" Description="Mod Type" Type="Variable" Display="always" Required="true" Mask="false">CURSEFORGE</Config>

--- a/antonyhanna/itzg-minecraft-server-ftb.xml
+++ b/antonyhanna/itzg-minecraft-server-ftb.xml
@@ -22,7 +22,6 @@
 	<Labels/>
 	<ExtraParams>-i -t</ExtraParams>
 	<Config Name="EULA" Target="EULA" Default="true" Mode="" Description="End User License Agreement" Type="Variable" Display="always" Required="true" Mask="false">true</Config>
-	<Config Name="Version" Target="VERSION" Default="" Mode="" Description="Server Version" Type="Variable" Display="always" Required="true" Mask="false"></Config>
 	<Config Name="Server Port" Target="25565" Default="25565" Mode="tcp" Description="Host Port" Type="Port" Display="always" Required="true" Mask="false">25565</Config>
 	<Config Name="Data" Target="/data" Default="!" Mode="/mnt/cache/appdata/minecraft-server" Description="Data Mount" Type="Path" Display="always" Required="true" Mask="false">/mnt/cache/appdata/minecraft-server</Config>
 	<Config Name="Type" Target="TYPE" Default="FTB" Mode="" Description="Mod Type" Type="Variable" Display="always" Required="true" Mask="false">FTB</Config>

--- a/antonyhanna/itzg-minecraft-server-spigot.xml
+++ b/antonyhanna/itzg-minecraft-server-spigot.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Container>
-	<Name>minecraft-server-ftb</Name>
+	<Name>minecraft-server-spigot</Name>
 	<TemplateURL>https://raw.githubusercontent.com/AntonyHanna/docker-templates/master/antonyhanna/itzg-minecraft-server-ftb.xml</TemplateURL>
 	<Beta>True</Beta>
 	<Category>GameServers</Category>


### PR DESCRIPTION
says the title is minecraft-server-ftb as opposed to correct title of minecraft-server-spigot
typo is fixed in this commit